### PR TITLE
Make this work for Kicad 6.x

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,7 +134,10 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
     def Run(self):
         board = pcbnew.GetBoard()
-        modules = board.GetModules()
+        if hasattr(board, 'GetModules'):
+            modules = board.GetModules()
+        else:
+            modules = board.GetFootprints()
 
         fn = Path(board.GetFileName()).with_suffix("")
 

--- a/bom2jlc.py
+++ b/bom2jlc.py
@@ -13,7 +13,10 @@ ref_ignore = ["TP", "T", "NT", "REF***", "G", "H"]
 def parse_pcb(fn):
     pcb_fn = str(Path(fn).with_suffix("")) + ".kicad_pcb"
     board = pcbnew.LoadBoard(pcb_fn)
-    modules = board.GetModules()
+    if hasattr(board, 'GetModules'):
+        modules = board.GetModules()
+    else:
+        modules = board.GetFootprints()
 
     for mod in modules:
         ref = mod.GetReference()


### PR DESCRIPTION
Kicad 6.x changed the API for obtaining the list of footprints in a file. This change is compatible with both 6.x and older versions.