### PR TITLE
Update for PCBNew 8

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,7 +134,7 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
     def Run(self):
         board = pcbnew.GetBoard()
-        modules = board.GetModules()
+        modules = board.GetFootprints()
 
         fn = Path(board.GetFileName()).with_suffix("")
 
@@ -162,7 +162,6 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
             pos = mod.GetPosition()
             rot = mod.GetOrientationDegrees()
-            desc = mod.GetDescription()
             layer = board.GetLayerName(mod.GetLayer())
             mid_x = Decimal(pos[0]) / Decimal(1000000)
             mid_y = Decimal(pos[1]) / Decimal(-1000000)

--- a/bom2jlc.py
+++ b/bom2jlc.py
@@ -13,7 +13,7 @@ ref_ignore = ["TP", "T", "NT", "REF***", "G", "H"]
 def parse_pcb(fn):
     pcb_fn = str(Path(fn).with_suffix("")) + ".kicad_pcb"
     board = pcbnew.LoadBoard(pcb_fn)
-    modules = board.GetModules()
+    modules = board.GetFootprints()
 
     for mod in modules:
         ref = mod.GetReference()


### PR DESCRIPTION
I found that this plugin was no longer working in KiCad 8.0 from Ubuntu Snap.
This fixes it, I was able to generate a CPL.
The description was never used anyway so I removed the broken call.