### PR TITLE
Update kicad API calls

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,7 +134,7 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
     def Run(self):
         board = pcbnew.GetBoard()
-        modules = board.GetModules()
+        modules = board.GetFootprints()
 
         fn = Path(board.GetFileName()).with_suffix("")
 
@@ -162,7 +162,7 @@ class JLCSMTPlugin(pcbnew.ActionPlugin):
 
             pos = mod.GetPosition()
             rot = mod.GetOrientationDegrees()
-            desc = mod.GetDescription()
+            desc = mod.GetLibDescription()
             layer = board.GetLayerName(mod.GetLayer())
             mid_x = Decimal(pos[0]) / Decimal(1000000)
             mid_y = Decimal(pos[1]) / Decimal(-1000000)

--- a/bom2jlc.py
+++ b/bom2jlc.py
@@ -13,7 +13,7 @@ ref_ignore = ["TP", "T", "NT", "REF***", "G", "H"]
 def parse_pcb(fn):
     pcb_fn = str(Path(fn).with_suffix("")) + ".kicad_pcb"
     board = pcbnew.LoadBoard(pcb_fn)
-    modules = board.GetModules()
+    modules = board.GetFootprints()
 
     for mod in modules:
         ref = mod.GetReference()


### PR DESCRIPTION
The kicad Python API has been updated, renaming some functions, including `GetModules` (with equivalent functionality now available as `GetFootprints`) as well as `GetDescription` (which is now `GetLibDescription`).

Some more info can be seen at:
* https://docs.kicad.org/doxygen-python-8.0/classpcbnew_1_1BOARD.html (for getting footprints from the board)

And comparing v6/v8 of:
* https://docs.kicad.org/doxygen-python-6.0/classpcbnew_1_1FOOTPRINT.html (old)
* https://docs.kicad.org/doxygen-python-8.0/classpcbnew_1_1FOOTPRINT.html (new)